### PR TITLE
Remove leading spaces from URL lines in emails.

### DIFF
--- a/templates/emails/confirm
+++ b/templates/emails/confirm
@@ -4,7 +4,7 @@ your letter to
 
 A copy of your letter is at the end of this email.
 
-    <?=$values['confirm_url']?>
+<?=$values['confirm_url']?>
 
 If your email program does not let you click on this link, copy and paste
 it into your web browser and press return.

--- a/templates/emails/confirm-group
+++ b/templates/emails/confirm-group
@@ -2,7 +2,7 @@ Please click on the link below to confirm that you wish WriteToThem.com to send
 the letter copied at the bottom of this email to your
 <?=$values['recipient_position_plural']?>:
 
-    <?=$values['confirm_url']?>
+<?=$values['confirm_url']?>
 
 If your email program does not let you click on this link, copy and paste
 it into your web browser and press return.

--- a/templates/emails/confirm-reminder
+++ b/templates/emails/confirm-reminder
@@ -4,7 +4,7 @@ Please click on the link below to confirm that you wish WriteToThem.com to send
 the letter copied at the bottom of this email to
 <?=$values['recipient_name']?>, your <?=$values['recipient_position']?>:
 
-    <?=$values['confirm_url']?>
+<?=$values['confirm_url']?>
 
 If your email program does not let you click on this link, copy and paste
 it into your web browser and press return.

--- a/templates/emails/confirm-reminder-group
+++ b/templates/emails/confirm-reminder-group
@@ -4,7 +4,7 @@ Please click on the link below to confirm that you wish WriteToThem.com to send
 the letter copied at the bottom of this email to your
 <?=$values['recipient_position_plural']?>:
 
-    <?=$values['confirm_url']?>
+<?=$values['confirm_url']?>
 
 If your email program does not let you click on this link, copy and paste
 it into your web browser and press return.

--- a/templates/emails/questionnaire
+++ b/templates/emails/questionnaire
@@ -5,12 +5,12 @@ letter at the bottom of this email)
 - If you HAVE had a reply (not just an acknowledgement), please
 click on the link below:
 
-    <?=$values['yes_url']?>
+<?=$values['yes_url']?>
 
 - If you HAVE NOT had any reply at all, OR you have only had an
 acknowledgement, please click on the link below:
 
-    <?=$values['no_url']?>
+<?=$values['no_url']?>
 
 If you feel that neither link is suitable, then please do not answer the
 questionnaire.

--- a/templates/emails/reply-autoresponse-questionnaire
+++ b/templates/emails/reply-autoresponse-questionnaire
@@ -9,12 +9,12 @@ A few weeks ago we sent your letter to your representative.
 - If you HAVE had a reply (not just an acknowledgement), please
 click on the link below:
 
-    <?=$values['yes_url']?>
+<?=$values['yes_url']?>
 
 - If you HAVE NOT had a reply, or you have only had an acknowledgement, please
 click on the link below:
 
-    <?=$values['no_url']?>
+<?=$values['no_url']?>
 
 If you feel that neither link is suitable, then please do not answer the
 questionnaire. If you have a question or comment about the site, please send an


### PR DESCRIPTION
Change made to see if it solves the problem of some email clients not correctly parsing URLs.
