### PR TITLE
Patch to redirect Rochester & Strood to Tracey Crouch

### DIFF
--- a/web/who.php
+++ b/web/who.php
@@ -75,7 +75,7 @@ foreach ($va_display_order as $va_types) {
     }
 
     // Data bad due to election etc?
-    if ( $disabled = check_area_status($va_areas[0]) ) {
+    if ( $disabled = check_area_status($va_areas[0], $fyr_postcode) ) {
         $text = $disabled;
         $heading = "<strike>$heading</strike>";
     }
@@ -493,7 +493,7 @@ for your region have informed us that they have divided it into areas, with ';
     return $text;
 }
 
-function check_area_status( $va_alone ) {
+function check_area_status( $va_alone, $pc ) {
     $parent_status = dadem_get_area_status($va_alone['parent_area']);
     dadem_check_error($parent_status);
     $status = dadem_get_area_status($va_alone['id']);
@@ -511,6 +511,9 @@ function check_area_status( $va_alone ) {
     } elseif ($status == "pending_election" || $parent_status == "pending_election") {
         $text = "<p>There's an upcoming election.  We'll be adding your new
                 representative as soon as we can after the election.</p>";
+        if ($va_alone['id'] = 66043) {
+            $text .= '<p>In the meantime you can contact <a href="' . general_write_rep_url(46719, $pc) . '">Tracey Crouch MP</a> with any correspondence.</p>';
+        }
     } else {
         $text = "Representative details are not available for an unknown reason.";
     }

--- a/web/write.php
+++ b/web/write.php
@@ -749,7 +749,9 @@ if ($stash['group_msg']) {
         mapit_check_error($postcode_areas);
         $area_ids = array_keys($postcode_areas['areas']);
         if (!in_array($fyr_representative['voting_area'], $area_ids)) {
-            mismatch_error();
+            if (!(in_array(66043, $area_ids) AND $fyr_representative['id'] = 46719)) {
+                mismatch_error();
+            }
         }
         $eb_type = $va_inside[$fyr_voting_area['type']];
         foreach ($postcode_areas['areas'] as $id => $arr) {


### PR DESCRIPTION
- Closes #205

Specifically:
- When viewing the 'who' page, if the user is in the Rochester & Strood area, append some extra text linking to the write page for Tracey Crouch with the Rochester & Strood postcode.
- When the 'write' page tests for validity, short circuit the logic for throwing an error if the person is writing to the Rochester & Strood area and Tracey Crouch is the representative in question.
