### PR TITLE
GovEval doesn't help keep email addresses up to date

### DIFF
--- a/templates/website/about-qa.html
+++ b/templates/website/about-qa.html
@@ -189,7 +189,7 @@ Once you have confirmed your message by clicking that link, it will probably hav
 <dt><a name="guarantee"></a>Can you guarantee my message will be sent?</dt>
 
 <dd>
-<p>Sadly, no. There are more than 24,000 representatives in our database. While <a href="http://www.goveval.com/">GovEval</a> help us keep them up to date, email addresses can change; inboxes can become overfull; representatives can retire; council or parliament (or our!) servers can fail. </p>
+<p>Sadly, no. There are more than 24,000 representatives in our database. Email addresses can change; inboxes can become overfull; representatives can retire; council or parliament (or our!) servers can fail. </p>
 <p>We do everything we can to spot and eliminate problems though, so please let us know if you have found any issues. </p>
 <p>Of course, if your message doesn't get through for any reason, we'll let you know.</p>
 


### PR DESCRIPTION
Sentence construction suggests GovEval helps mySociety keep email addresses up to date, but @dracos says this is false: https://groups.google.com/d/msg/poplus/CQ1BRPB942o/wRzcMxfXXbYJ

Keeping names and parties up-to-date is not relevant to successful email delivery, so the mention of GovEval here appears to be spurious and confusing.