### PR TITLE
Remove the homepage title A/B test from December 2013

### DIFF
--- a/templates/common_header.php
+++ b/templates/common_header.php
@@ -45,32 +45,6 @@ if (isset($values['cobrand']))
 
     <?php if (OPTION_WEB_DOMAIN == 'writetothem.com'): ?>
 
-    <?php
-        $url = parse_url($_SERVER['REQUEST_URI']);
-        if ($url['path'] == '/' && isset($values['experiment']) && $values['experiment']) {
-    ?>
-        <!-- Load GA experiments API -->
-        <script src="//www.google-analytics.com/cx/api.js?experiment=9AJDuy1gQjiG51CmMpaVlg"></script>
-        <script>
-            // Select GA experiment variation
-            var chosenVariation = cxApi.chooseVariation();
-
-            // Text variations to use
-            var pageVariations = [
-
-                function() {    // Original
-                    document.getElementById('title').innerHTML = 'Write to your politicians, national or local, for free.';
-                },
-                function() {    // Variant 1
-                    document.getElementById('title').innerHTML = 'Email your MP, local councillors or other representatives.';
-                },
-                function() {    // Variant 2
-                    document.getElementById('title').innerHTML = 'Email the people in power.';
-                }
-            ];
-        </script>
-    <?php } ?>
-
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
The A/B test was started in https://github.com/mysociety/writetothem/commit/e05dc1c0ba424cef803500fc22e1f7d5a9b424e7. 

@jacksonj04 says it's not come to any significant conclusion yet, so it's safe to assume it never will.

This PR just removes the Google Analytics Experiment code from the homepage header template.