### PR TITLE
Privacy Policy Updates

### DIFF
--- a/templates/website/about-privacy.html
+++ b/templates/website/about-privacy.html
@@ -110,33 +110,42 @@ other companies, you can adjust your usage or install opt-out browser plugins.
     <p>To make our service easier or more useful, we sometimes place small data
     files on your computer or mobile phone, known as cookies; many websites do
     this. We use this information to measure how people use the website so we
-    can improve it and make sure it works properly. Below, we list the cookies
-    and services that this site can use.
+    can improve it and make sure it works properly. Below, we give more
+    information on which cookies we use.</p>
 
     <h3>Measuring website usage (Google Analytics)</h3>
 
         <p>We use Google Analytics to collect information about how people use
         this site. We do this to make sure it’s meeting its users’ needs and to
-        understand how we could do it better. Google Analytics stores
-        information such as what pages you visit, how long you are on the site,
-        how you got here, what you click on, and information about your web
-        browser. IP addresses are masked (only a portion is stored) and
-        personal information is only reported in aggregate. We do not allow
-        Google to use or share our analytics data for any purpose besides
-        providing us with analytics information, and we recommend that any user
-        of Google Analytics does the same.</p>
+        understand how we could do it better.</p>
 
-        <p>If you’re unhappy with data about your visit to be used in this way,
-        you can install the <a
-        href="https://tools.google.com/dlpage/gaoptout">official browser plugin
-        for blocking Google Analytics</a>.
+        <p>Google Analytics stores information such as what pages you visit,
+        how long you are on the site, how you got here, what you click on, and
+        information about your web browser.</p>
 
-        <p>The cookies set by Google Analytics are as follows:
+        <p>IP addresses are masked (only a portion is stored) and personal
+        information is only reported in aggregate.</p>
 
-        <table cellpadding="5">
-        <tr align="left"><th scope="col">Name</th><th scope="col">Typical Content</th><th scope="col">Expires</th></tr>
-        <tr><td>_ga</td><td>Unique anonymous visitor ID</td><td>2 years</td></tr>
-        </table>
+        <p>We have also enabled the Advertising Features of Google Analytics.
+        In particular, we use <b>Demographics and Interest reporting</b> to
+        identify trends in the types of users visiting our site, which may be
+        used for internal reporting and improvement of the site content.</p>
+
+        <p>In technical speak, this allows Google to collect data about your
+        traffic via Google <a
+        href="http://www.google.com/policies/technologies/types/">advertising
+        cookies</a> and <a
+        href="https://www.google.com/policies/privacy/key-terms/#toc-terms-identifier">anonymous
+        identifiers</a>, in addition to data collected through a standard
+        Google Analytics implementation. Regardless of the source of the data,
+        we strictly adhere to <a
+        href="https://support.google.com/analytics/answer/2700409">Google’s
+        policy requirements</a> in our treatment of your data. We do not
+        facilitate the merging of personally-identifiable information with
+        non-personally identifiable information collected through any Google
+        advertising product or feature. We do not allow Google to use or share
+        our analytics data for any purpose besides providing us with analytics
+        information.</p>
 
         <h4>Google’s Official Statement about Analytics Data</h4>
 
@@ -159,7 +168,18 @@ other companies, you can adjust your usage or install opt-out browser plugins.
         to the processing of data about you by Google in the manner and for the
         purposes set out above.”</p>
 
-        <p><a href="https://www.mysociety.org/privacy-online/">More general information on how third party services work</a></p>
+        <h4>Opting out</h4>
+        <p>If you’re unhappy with the idea of sharing the fact you
+        visited our site (and any other sites) with Google, you can
+        <a href="https://tools.google.com/dlpage/gaoptout/">install the
+        official browser plugin for blocking Google Analytics</a>.</p>
+
+        <p>If you want to disable advertising-based tracking, you can
+        <a href="https://www.google.com/settings/ads">adjust your Google Ads
+        Settings</a>, or opt out of advertising-based tracking across a
+        number of providers in one go using the
+        <a href="http://www.networkadvertising.org/choices/">Network
+        Advertising Initiative’s opt-out form</a>.</p>
 
 <h2>Email Opt-Out</h2>
 

--- a/templates/website/about-privacy.html
+++ b/templates/website/about-privacy.html
@@ -37,90 +37,137 @@ other companies, you can adjust your usage or install opt-out browser plugins.
 
 <ul>
 
-<li>We will pass on your message, name, email and postal address
-and (optionally) telephone number either direct to the politician(s)
-you write to, or to a trusted intermediary (such as a council
-democratic services department) who will then pass it on.
-</li>
-<li>We will never sell or otherwise distribute any information you give
-WriteToThem to organisations or individuals outside of mySociety, except in the
-following circumstances:
-<ul>
-<li>when required to do so by UK law;
-<li>if you come to the site via louder.org.uk, we are given a unique ID that we
-pass back to them when you confirm your message. If you were logged in to
-louder.org.uk, they will know you have <em>sent</em> a message (but nothing else).
-</ul>
-</li>
-<li> We will store your IP address and the pages that you visited whilst
-on the site as part of our site logs. We keep these for one month.
-</li>
-<li> We will never keep permanent copies of the letters you write to send
-to your representatives, and will not look at your messages unless
-there is a problem with the operation of the site which requires us
-to do so.
-</li>
-<li>We will store the content of your message for four weeks after it was
-dispatched. Then it is automatically deleted. We keep a copy in backup files
-for one additional week. We need to keep it for this long to monitor and
-prevent abuse of the service. It also means we can include a copy of your
-message in the email which asks if your representative has
-responded yet.</li>
-<li>If delivery of a message fails for a week, we keep the message content for
-a further 8 weeks.  This gives us time to diagnose the problem. We sometimes
-need the content so we can resend the message.
-<li> We keep records of names and addresses for longer periods in order
-to provide an audit trail if a representative queries the accuracy of
-the statistics on response rates we produce. We will never give these
-out to a representative on any other occasion than when you send them
-your message.
-</li>
-<li> If you contact mySociety via our support email address we reserve the
-right to keep your support message indefinitely, especially if you say
-something nice about us.
-</li>
-<li>We use cookies to track how people use mySociety sites, and how they
-move between them. We do this only to make our sites work better, and we will
-never give away the data that we collect in this way.</li>
-<li> We will never send you unsolicited email except:
-a) One survey email and up to one reminder two weeks after you send
-your message.
-b) In the rare case that a politician asks us to pass a message on their behalf
-to survey respondents in their constituency/ward who say they have not heard
-back from them.
-</li>
+    <li>We will pass on your message, name, email and postal address
+    and (optionally) telephone number either direct to the politician(s)
+    you write to, or to a trusted intermediary (such as a council
+    democratic services department) who will then pass it on.
+    </li>
+
+    <li>We will never sell or otherwise distribute any information you give
+    WriteToThem to organisations or individuals outside of mySociety, except in the
+    following circumstances:
+
+        <ul>
+            <li>when required to do so by UK law;</li>
+            <li>if you come to the site via louder.org.uk, we are given a unique ID that we
+            pass back to them when you confirm your message. If you were logged in to
+            louder.org.uk, they will know you have <em>sent</em> a message (but nothing else).</li>
+        </ul>
+    </li>
+
+    <li> We will store your IP address and the pages that you visited whilst
+    on the site as part of our site logs. We keep these for one month.
+    </li>
+
+    <li> We will never keep permanent copies of the letters you write to send
+    to your representatives, and will not look at your messages unless
+    there is a problem with the operation of the site which requires us
+    to do so.
+    </li>
+
+    <li>We will store the content of your message for four weeks after it was
+    dispatched. Then it is automatically deleted. We keep a copy in backup files
+    for one additional week. We need to keep it for this long to monitor and
+    prevent abuse of the service. It also means we can include a copy of your
+    message in the email which asks if your representative has
+    responded yet.
+    </li>
+
+    <li>If delivery of a message fails for a week, we keep the message content for
+    a further 8 weeks.  This gives us time to diagnose the problem. We sometimes
+    need the content so we can resend the message.
+    </li>
+
+    <li> We keep records of names and addresses for longer periods in order
+    to provide an audit trail if a representative queries the accuracy of
+    the statistics on response rates we produce. We will never give these
+    out to a representative on any other occasion than when you send them
+    your message.
+    </li>
+
+    <li> If you contact mySociety via our support email address we reserve the
+    right to keep your support message indefinitely, especially if you say
+    something nice about us.
+    </li>
+
+    <li>We use cookies to track how people use mySociety sites, and how they
+    move between them. We do this only to make our sites work better, and we will
+    never give away the data that we collect in this way.
+    </li>
+
+    <li> We will never send you unsolicited email except:<br>
+    a) One survey email and up to one reminder two weeks after you send
+    your message.<br>
+    b) In the rare case that a politician asks us to pass a message on their behalf
+    to survey respondents in their constituency/ward who say they have not heard
+    back from them.
+    </li>
+
 </ul>
 
 <h2>Cookies</h2>
 
-<p>To make our service easier or more useful, we sometimes place small data files on your computer or mobile phone, known as cookies; many websites do this. We use this information to measure how people use the website so we can improve it and make sure it works properly. Below, we list the cookies and services that this site can use.
+    <p>To make our service easier or more useful, we sometimes place small data
+    files on your computer or mobile phone, known as cookies; many websites do
+    this. We use this information to measure how people use the website so we
+    can improve it and make sure it works properly. Below, we list the cookies
+    and services that this site can use.
 
-<h3>Measuring website usage (Google Analytics)</h3>
+    <h3>Measuring website usage (Google Analytics)</h3>
 
-<p>We use Google Analytics to collect information about how people use this site. We do this to make sure it’s meeting its users’ needs and to understand how we could do it better. Google Analytics stores information such as what pages you visit, how long you are on the site, how you got here, what you click on, and information about your web browser. IP addresses are masked (only a portion is stored) and personal information is only reported in aggregate. We do not allow Google to use or share our analytics data for any purpose besides providing us with analytics information, and we recommend that any user of Google Analytics does the same.</p>
+        <p>We use Google Analytics to collect information about how people use
+        this site. We do this to make sure it’s meeting its users’ needs and to
+        understand how we could do it better. Google Analytics stores
+        information such as what pages you visit, how long you are on the site,
+        how you got here, what you click on, and information about your web
+        browser. IP addresses are masked (only a portion is stored) and
+        personal information is only reported in aggregate. We do not allow
+        Google to use or share our analytics data for any purpose besides
+        providing us with analytics information, and we recommend that any user
+        of Google Analytics does the same.</p>
 
-<p>If you’re unhappy with data about your visit to be used in this way, you can install the <a href="https://tools.google.com/dlpage/gaoptout">official browser plugin for blocking Google Analytics</a>.
+        <p>If you’re unhappy with data about your visit to be used in this way,
+        you can install the <a
+        href="https://tools.google.com/dlpage/gaoptout">official browser plugin
+        for blocking Google Analytics</a>.
 
-<p>The cookies set by Google Analytics are as follows:
+        <p>The cookies set by Google Analytics are as follows:
 
-<table cellpadding="5">
-<tr align="left"><th scope="col">Name</th><th scope="col">Typical Content</th><th scope="col">Expires</th></tr>
-<tr><td>_ga</td><td>Unique anonymous visitor ID</td><td>2 years</td></tr>
-</table>
+        <table cellpadding="5">
+        <tr align="left"><th scope="col">Name</th><th scope="col">Typical Content</th><th scope="col">Expires</th></tr>
+        <tr><td>_ga</td><td>Unique anonymous visitor ID</td><td>2 years</td></tr>
+        </table>
 
-<h4>Google’s Official Statement about Analytics Data</h4>
+        <h4>Google’s Official Statement about Analytics Data</h4>
 
-<p>“This website uses Google Analytics, a web analytics service provided by Google, Inc. (“Google”). Google Analytics uses “cookies”, which are text files placed on your computer, to help the website analyze how users use the site. The information generated by the cookie about your use of the website (including your IP address) will be transmitted to and stored by Google on servers in the United States . Google will use this information for the purpose of evaluating your use of the website, compiling reports on website activity for website operators and providing other services relating to website activity and internet usage.  Google may also transfer this information to third parties where required to do so by law, or where such third parties process the information on Google’s behalf. Google will not associate your IP address with any other data held by Google.  You may refuse the use of cookies by selecting the appropriate settings on your browser, however please note that if you do this you may not be able to use the full functionality of this website.  By using this website, you consent to the processing of data about you by Google in the manner and for the purposes set out above.”</p>
+        <p>“This website uses Google Analytics, a web analytics service
+        provided by Google, Inc. (“Google”). Google Analytics uses “cookies”,
+        which are text files placed on your computer, to help the website
+        analyze how users use the site. The information generated by the cookie
+        about your use of the website (including your IP address) will be
+        transmitted to and stored by Google on servers in the United States .
+        Google will use this information for the purpose of evaluating your use
+        of the website, compiling reports on website activity for website
+        operators and providing other services relating to website activity and
+        internet usage.  Google may also transfer this information to third
+        parties where required to do so by law, or where such third parties
+        process the information on Google’s behalf. Google will not associate
+        your IP address with any other data held by Google.  You may refuse the
+        use of cookies by selecting the appropriate settings on your browser,
+        however please note that if you do this you may not be able to use the
+        full functionality of this website.  By using this website, you consent
+        to the processing of data about you by Google in the manner and for the
+        purposes set out above.”</p>
 
-<p><a href="https://www.mysociety.org/privacy-online/">More general information on how third party services work</a></p>
+        <p><a href="https://www.mysociety.org/privacy-online/">More general information on how third party services work</a></p>
 
 <h2>Email Opt-Out</h2>
 
-<p>As part of the process of sending your message to your representative we will send you a limited number of emails <a href="/about-qa#stop">as described here</a>. If during this process you wish to stop receiving emails from us, or you are a representative who no longer wishes to receive email via WriteToThem, please contact us at <a href="mailto:<?=$contact_email?>"><?=$contact_email?></a>.</p>
+    <p>As part of the process of sending your message to your representative we will send you a limited number of emails <a href="/about-qa#stop">as described here</a>. If during this process you wish to stop receiving emails from us, or you are a representative who no longer wishes to receive email via WriteToThem, please contact us at <a href="mailto:<?=$contact_email?>"><?=$contact_email?></a>.</p>
 
 <h2>Credits</h2>
 
-<p>Bits of wording taken from the <a href="http://gov.uk/help/cookies">GOV.UK cookies page</a> (under the Open Government Licence).
+    <p>Bits of wording taken from the <a href="http://gov.uk/help/cookies">GOV.UK cookies page</a> (under the Open Government Licence).
 
             </div>
 


### PR DESCRIPTION
Update the privacy policy to be in step with mySociety.co.uk and TWFY, in that it explicitly allows us to use the [demographics and interest tools](https://support.google.com/analytics/answer/2799357?hl=en) in Google Analytics.

As far as I can tell this still doesn't change the intent of our previous Google Analytics statement:
* We're still only using the data in aggregate, we can't identify people, and it's to improve the site.
* We still not sending our analytics data elsewhere (the information flows *from* the advertising network *to* analytics, we're still not sending anything back).
* From [Google's docs on the subject](https://support.google.com/analytics/answer/2799357?hl=en#where), "Neither analytics.js nor ga.js collects Demographics and Interests data". We won't be setting or updating any advertising cookies.