### PR TITLE
Prevent errors when database restarted

### DIFF
--- a/perllib/FYR/Queue.pm
+++ b/perllib/FYR/Queue.pm
@@ -2007,29 +2007,6 @@ sub notify_daemon () {
     $s->close();
 }
 
-=item get_time
-
-Returns the current time, in Unix seconds since epoch. This may not
-be the real world time, as it can be overriden in the database for
-the test script.
-
-=cut
-sub get_time () {
-    my ($id, $user) = @_;
-    return scalar(dbh()->selectrow_array("select extract(epoch from fyr_current_timestamp())", {}));
-}
-
-=item get_date
-
-Returns the current date, in iso format. This may not be the real world date,
-as it can be overriden in the database for the test script.
-
-=cut
-sub get_date () {
-    my ($id, $user) = @_;
-    return scalar(dbh()->selectrow_array("select fyr_current_date()", {}));
-}
-
 #
 # Administrative interface
 #

--- a/perllib/FYR/Queue.pm
+++ b/perllib/FYR/Queue.pm
@@ -526,8 +526,7 @@ sub logmsg_set_handler ($) {
 sub logmsg ($$$;$) {
     my ($id, $important, $msg, $editor) = @_;
     our $dbh;
-    # XXX should ping
-    $dbh ||= new_dbh();
+    ($dbh) = mySociety::DBHandle::dbh_test($dbh);
     our $log_hostname;
     $log_hostname ||= (POSIX::uname())[1];
     $dbh->do('

--- a/phplib/queue.php
+++ b/phplib/queue.php
@@ -239,29 +239,6 @@ function msg_get_questionnaire_message($token) {
     return $result;
 }
 
-/* msg_get_time
-
-  Returns the current time, in Unix seconds since epoch. This may not be
-  the real world time, as it can be overriden in the database for the test
-  script. */
-function msg_get_time() {
-    global $msg_client;
-    $params = func_get_args();
-    $result = $msg_client->call('FYR.Queue.get_time', $params);
-    return $result;
-}
-
-/* msg_get_date
-
-  Returns the current date, in iso format. This may not be the real world
-  date, as it can be overriden in the database for the test script. */
-function msg_get_date() {
-    global $msg_client;
-    $params = func_get_args();
-    $result = $msg_client->call('FYR.Queue.get_date', $params);
-    return $result;
-}
-
 /* msg_admin_recent_events COUNT [IMPORTANT]
 
   Returns an array of hashes of information about the most recent COUNT

--- a/web/services/queue.cgi
+++ b/web/services/queue.cgi
@@ -64,12 +64,6 @@ while ($req->Accept() >= 0) {
             'FYR.Queue.get_questionnaire_message' => sub {
                 return FYR::Queue::get_questionnaire_message($_[0]);
             },
-            'FYR.Queue.get_time' => sub {
-                return FYR::Queue::get_time();
-            },
-            'FYR.Queue.get_date' => sub {
-                return FYR::Queue::get_date();
-            },
             'FYR.Queue.admin_recent_events' => sub {
                 return FYR::Queue::admin_recent_events($_[0], $_[1]);
             },

--- a/web/write.php
+++ b/web/write.php
@@ -333,14 +333,6 @@ function renderForm($form, $pageName, $options)
         $fyr_form = $form;
     }
 
-    // Add time-shift warning if in debug mode
-    if (OPTION_FYR_REFLECT_EMAILS) {
-        $fyr_today = strftime('%Y-%m-%d', $stash['time']);
-        if ($fyr_today != date('Y-m-d')) {
-            $fyr_form = "<p style=\"text-align: center; color: #ff0000; \">Note: On this test site, the date is faked to be $fyr_today</p>" . $fyr_form;
-        }
-    }
-
     $prime_minister = false;
     if ($fyr_values['who'] == 47292) { # Hardcoded
         $prime_minister = true;
@@ -611,9 +603,7 @@ set_up_variables($fyr_values);
 
 // Various display and used fields, global variables
 $stash = array();
-$stash['time'] = msg_get_time();
-msg_check_error($stash['time']);
-$stash['date'] = strftime('%A %e %B %Y', $stash['time']);
+$stash['date'] = strftime('%A %e %B %Y');
 
 if (!isset($fyr_values['who']) || ($fyr_values['who'] == "all" && !isset($fyr_values['type']))) {
     back_to_who();


### PR DESCRIPTION
This adds connection testing to the logmsg() function; https://github.com/mysociety/commonlib/commit/dd132fdd1b3bc9fb3f683cdf1f123d3477ec61eb is the commonlib change factors that out from the shared handle function so it can be used here.

It also removes get_time/get_date functions; the DBD::Pg ping returns immediately if you are in a transaction, without checking against the db, so with the get_time calls happening you were always going to be in a transaction when a message was written, meaning only the actual write would error (and be lost), rather than with the ping. Now, it should much more likely be outside a transaction (I think?) and so an error caught and reconnected before message insertion.

Test suite passes on firefly.