### PR TITLE
Remove fax monitoring

### DIFF
--- a/bin/admin_reminder_mail
+++ b/bin/admin_reminder_mail
@@ -73,17 +73,6 @@ $freq_referrers_week = msg_admin_get_popular_referrers(60 * 60 * 24 * 7);
 // Prepare email...
 $mail = '';
 
-// Check fax sent in last day
-verbose("checking fax sent in last day");
-$fax_last_days_ago = (time() - $stats['last_fax_time']) / (60 * 60 * 24);
-if ($fax_last_days_ago >= 1) {
-    $fax_last_days_ago = round($fax_last_days_ago, 1);
-    $mail .= "
-* A fax was last sent $fax_last_days_ago days ago, which is more than one day.
-  Kick the fax servers! They're all probably broken.
-";
-}
-
 // Messages in "need attention" state
 verbose("getting messages in 'need attention' state");
 $need_attention_messages = msg_admin_get_queue('needattention', array());


### PR DESCRIPTION
Updates the admin_reminder_mail script to stop monitoring a non-existent fax server; fixes #293.