### PR TITLE
Promote EveryPolitician on campaigns page

### DIFF
--- a/templates/website/about-campaigns.html
+++ b/templates/website/about-campaigns.html
@@ -25,7 +25,11 @@ template_draw('header', $values);
 <ul>
 <li> WriteToThem is <b>not a petitioning site</b>. If you need to collect signatures on a petition and then send it to an MP, you&rsquo;d be better off with one of the many free online petition websites. </li>
 
-<li> We <b>can&rsquo;t give out MPs&rsquo; contact details</b>. Direct email and postal addresses for most MPs can be found on <a href="http://www.parliament.uk/mps-lords-and-offices/mps/">Parliament&rsquo;s website</a>.</li>
+<li>We <b>don’t give out MPs’ contact details</b>. Direct email and postal
+addresses for most MPs can be found on <a
+href="http://www.parliament.uk/mps-lords-and-offices/mps/">Parliament’s
+website</a> or via the <a
+href="http://everypolitician.org/">EveryPolitician</a> project.</a>.</li>
 
 <li>WriteToThem cannot be used for sending out <b>identically-worded messages</b> from multiple supporters - our system will detect them and block them from being sent.</li>
 </ul>


### PR DESCRIPTION
People who want MPs' email addresses can get them from EveryPolitician these days, so we should say so.