### PR TITLE
Replace David Cameron with Theresa May

### DIFF
--- a/templates/website/write-write.html
+++ b/templates/website/write-write.html
@@ -33,24 +33,24 @@ template_draw('header', $values);
     <div class="large-10 large-centered columns">
 
         <div class="alert-box alert radius" role="alert">
-            Please only use this service to contact David Cameron if you are one of his
-            constituents in Witney.
+            Please only use this service to contact Theresa May if you are one of her
+            constituents in Maidenhead.
         </div>
 
         <p><a href="/about-qa#onlyrep">Click here to understand why doing otherwise is A Bad Thing</a>.</p>
 
-        <p>If you are <em>not</em> a constituent and wish to contact David Cameron, you
-        may write to him at the address below:</p>
+        <p>If you are <em>not</em> a constituent and wish to contact Theresa May, you
+        may write to her at the address below:</p>
 
         <ul class="vcard">
-          <li class="fn">The Rt Hon David Cameron</li>
+          <li class="fn">The Rt Hon Theresa May</li>
           <li class="title">Prime Minister</li>
           <li class="street-address">10 Downing Street</li>
           <li class="locality">London</li>
           <li class="zip">SW1A 2AS</li>
         </ul>
 
-        <p>If you are a constituent of Witney, read on...</p>
+        <p>If you are a constituent of Maidenhead, read on...</p>
 
         <hr>
 


### PR DESCRIPTION
The site already has Theresa May set as `prime_minister` but as the text is hard coded it still admonishes people not to write to David Cameron on her page. Fixes #349.