### PR TITLE
Remove postal address

### DIFF
--- a/templates/website/about-contact.html
+++ b/templates/website/about-contact.html
@@ -59,18 +59,6 @@ href="mailto:<?=$contact_email?>"><?=$contact_email?></a> for prompt
 action.
 </p>
 
-<h3>Postal address</h3>
-
-<p>If you wish to contact us by post, our address is:</p>
-
-<address>
-mySociety Ltd,<br>
-483 Green Lanes,<br>
-London,<br>
-N13 4BS<br>
-United Kingdom
-</address>
-
             </div>
 
             <div class="large-4 columns">


### PR DESCRIPTION
I don't think we need to include this, it's confusing people into posting us correspondence meant for their MP. (The address is still available on the mySociety website.)