### PR TITLE
Remove Christmas Donation Banner

### DIFF
--- a/conf/general-example
+++ b/conf/general-example
@@ -133,4 +133,7 @@ define('OPTION_SURVEY_URL', 'http://survey.mysociety.org');
 // Analytics
 define('OPTION_GOOGLE_ANALYTICS_TRACKING_CODE', '');
 
+// Donation or Recruitment message for top banner. No banner displayed if empty.
+define('BANNER_MESSAGE', '')
+
 ?>

--- a/templates/common_header.php
+++ b/templates/common_header.php
@@ -92,14 +92,17 @@ if (isset($values['cobrand']))
 
 <body <?php if (array_key_exists('body_class', $values)): ?>class="<?php echo $values['body_class']; ?>"<?php endif; ?>>
 
+<?php if (BANNER_MESSAGE): ?>
+
 <div class="banner banner--donate">
     <div class="row">
         <div class="large-10 large-centered columns">
-            <strong>Help keep our sites running in 2018.</strong>
-            <a href="https://www.mysociety.org/donate/">Please donate today</a>.
+            <?=BANNER_MESSAGE ?>
         </div>
     </div>
 </div>
+
+<?php endif; ?>
 
 <?php if (0 && OPTION_FYR_REFLECT_EMAILS): ?>
 


### PR DESCRIPTION
Banner concealed via logic rather than removed to make it easier to
turn back on in future. Text changed to reflect jump to
mySociety-branded donate page.

Do just delete the block if that makes more sense. 