### PR TITLE
Gemfile and updated README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "zurb-foundation"
+gem "compass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    chunky_png (1.3.10)
+    compass (1.0.3)
+      chunky_png (~> 1.2)
+      compass-core (~> 1.0.2)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.3)
+      multi_json (~> 1.0)
+      sass (>= 3.3.0, < 3.5)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    ffi (1.9.23)
+    multi_json (1.13.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    sass (3.4.25)
+    zurb-foundation (4.3.2)
+      sass (>= 3.2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  compass
+  zurb-foundation
+
+BUNDLED WITH
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -12,18 +12,28 @@ built from the start to be more flexible and easier to use.
 
 ### Stylesheets
 
-WriteToThem uses the [Foundation framework](http://foundation.zurb.com/), and
-styles are compiled using [Compass](http://compass-style.org/). Before you start
-editing files you will need some prerequisites, which can be installed as
-follows (you may need to use `sudo`):
+WriteToThem uses the [Foundation framework](http://foundation.zurb.com/),
+and styles are compiled using [Compass](http://compass-style.org/).
 
-* `gem install zurb-foundation` will install the necessary components of the framework.
-* `gem install compass` will install Compass, ready to compile assets.
+Most people prefer to manage their Ruby Gems using Bundler. If you don’t
+already have it, you can install it like so:
 
-The Sass files used to compile styles are located in `web/static/sass`. To
-compile them, `cd` to the `web/static` directory and run `compass compile`. If
-you are making frequent changes, `compass watch` will watch the directory for
-changes and recompile when necessary.
+    gem install bundler
+
+Then you can tell Bundler install the Gems for this project:
+
+    bundle install
+
+And finally, change into the Sass directory, and compile the Sass into CSS:
+
+    cd web/static
+    bundle exec compass compile
+
+If you are making frequent changes, you can tell Compass to watch the
+directory for updates, and recompile the CSS files as necessary:
+
+    cd web/static
+    bundle exec compass watch
 
 ## Acknowledgements
 


### PR DESCRIPTION
Came to work on WriteToThem today, and found it odd that the README suggested installing Gems globally. These days I get the feeling most people install Gems through—at the very least—Bundler, because at least then they’re scoped to just one particular project, rather than your whole machine.

Thoughts?