### PR TITLE
Add post-survey survey embed/link to questions about proxy use of WTT

### DIFF
--- a/templates/website/surveygizmo-proxy.html
+++ b/templates/website/surveygizmo-proxy.html
@@ -1,0 +1,25 @@
+<?php
+
+$values['title'] = "Help us by answering a few quick questions";
+$values['robots'] = 'noindex, nofollow';
+$url = 'https://www.surveygizmo.com/s3/4563120/A-few-more-questions-2?__no_style=true&amp;__ref=pol-info-survey&amp;message_id=' . $values['id'];
+
+template_draw('header', $values);
+
+?>
+
+<div class="row">
+    <div class="large-10 large-centered columns">
+
+        <script src="<?=$url?>&amp;__output=embedjs" type="text/javascript">
+        </script>
+
+        <noscript>
+        <a href="<?=$url?>&amp;jsfallback=true">Please click here to answer additional questions.</a>
+        </noscript>
+        <style>.sg-survey{display:none; }</style>
+
+    </div>
+</div>
+
+<?php template_draw('footer', $values);

--- a/web/firsttime.php
+++ b/web/firsttime.php
@@ -36,6 +36,13 @@ if (rabx_is_error($result)) {
 $values = msg_admin_get_message($result);
 $values['cobrand'] = $cobrand;
 
-// Questionnaire done
-template_draw("survey-done", $values);
 
+// Proxy Information Survey
+
+$rand = rand(0, 1); // high rate when want lots of data
+if ($rand == 0) {
+    template_draw("surveygizmo-proxy", $values);
+} else {
+    // Questionnaire done
+    template_draw("survey-done", $values);
+}


### PR DESCRIPTION
Further described in: https://github.com/mysociety/research/issues/151

This adds a post-survey embed (or a link to the survey if Javascript is off) to 50% of people writing to all types of representatives. 

This survey is not anonymous as it passes the message ID so responses can be reconciled with other features of message (postcode - and so deprivation by lsoa - and representative type). I think this is OK as we're not asking for personal or political information of the individual as we were with the last survey - and this is effectively the same status as the in-built questions. Open to alternate approaches, but I think even converting postcode to LSOA and passing wouldn't really be anonymous as time+lsoa is likely to be unique. 