### PR TITLE
Add option to use a particular MapIt generation.

### DIFF
--- a/bin/toggle-areas
+++ b/bin/toggle-areas
@@ -76,7 +76,8 @@ $status .= '_election' if $status =~ /pending|recent/;
 
 print "DRY RUN\n" unless $commit;
 
-my $areas_info = mySociety::MaPit::call('areas', $type);
+my $generation = mySociety::Config::get('MAPIT_GENERATION');
+my $areas_info = mySociety::MaPit::call('areas', $type, $generation ? (generation => $generation) : ());
 my $count = 0;
 foreach (keys %$areas_info) {
     next if $exceptions{$_};

--- a/conf/general-example
+++ b/conf/general-example
@@ -23,6 +23,9 @@ define('OPTION_DADEM_URL', 'http://services.mysociety.org/dadem');
 define('OPTION_MAPIT_URL', 'http://mapit.mysociety.org/');
 define('OPTION_RATTY_URL', 'http://services.mysociety.org/ratty');
 
+// If MapIt calls should use a particular generation
+define('OPTION_MAPIT_GENERATION', null);
+
 // Where the FYR queue service is.
 define('OPTION_FYR_QUEUE_URL', 'http://sometestdomain.writetothem.com/services/queue');
 define('OPTION_FYR_QUEUE_USERPWD', null);

--- a/perllib/FYR/AbuseChecks.pm
+++ b/perllib/FYR/AbuseChecks.pm
@@ -318,7 +318,8 @@ my @group_tests = (
             my $is_known = 0;
             my $yields_same_voting_area = 0;
             try {
-                my $areas = mySociety::MaPit::call('postcode', $newpc);
+                my $generation = mySociety::Config::get('MAPIT_GENERATION');
+                my $areas = mySociety::MaPit::call('postcode', $newpc, $generation ? (generation => $generation) : ());
                 $is_known = 1;
                 my $rep = mySociety::DaDem::get_representative_info($msg->{recipient_id});
                 #warn "va: $rep->{voting_area} dump: ".  Dumper(\%h). Dumper($rep);

--- a/phplib/admin-reps.php
+++ b/phplib/admin-reps.php
@@ -9,7 +9,7 @@
 
 $dir = dirname(__FILE__);
 require_once $dir . "/../commonlib/phplib/dadem.php";
-require_once $dir . "/../commonlib/phplib/mapit.php";
+require_once $dir . "/../phplib/mapit.php";
 require_once $dir . "/../commonlib/phplib/votingarea.php";
 require_once $dir . "/../commonlib/phplib/utility.php";
 
@@ -47,7 +47,7 @@ class ADMIN_PAGE_REPS
         foreach ($reps as $rep) {
             $areas[] = $info[$rep]['voting_area'];
         }
-        $area_info = mapit_call('areas', $areas);
+        $area_info = mapit_areas($areas);
         mapit_check_error($area_info);
 
         $generation = 0;
@@ -622,7 +622,7 @@ class ADMIN_PAGE_REPS
 
         $form = new HTML_QuickForm('adminRepsSearchResults', 'get', $this->self_link);
         $html = '';
-        $areas = mapit_call('areas', $this->params['search']);
+        $areas = mapit_areas($this->params['search']);
         mapit_check_error($areas);
         foreach (array_keys($areas) as $va_id) {
             $area_info = mapit_call('area', $va_id);
@@ -646,7 +646,7 @@ class ADMIN_PAGE_REPS
 
         $form = new HTML_QuickForm('adminRepsSearchResults', 'get', $this->self_link);
 
-        $voting_areas = mapit_call('postcode', $this->params['pc']);
+        $voting_areas = mapit_postcode($this->params['pc']);
         mapit_check_error($voting_areas);
         $areas_info = $voting_areas['areas'];
         $html = "";
@@ -706,13 +706,13 @@ class ADMIN_PAGE_REPS
         foreach ($corrections as $correction) {
             array_push($vaids, $correction['voting_area_id']);
         }
-        $info1 = mapit_call('areas', $vaids);
+        $info1 = mapit_areas($vaids);
         mapit_check_error($info1);
         $vaids = array();
         foreach ($info1 as $value) {
             array_push($vaids, $value['parent_area']);
         }
-        $info2 = mapit_call('areas', $vaids);
+        $info2 = mapit_areas($vaids);
 
         foreach ($corrections as $correction) {
             $form = new HTML_QuickForm('adminRepsCorrections', 'post', $this->self_link);

--- a/phplib/mapit.php
+++ b/phplib/mapit.php
@@ -1,0 +1,19 @@
+<?php
+
+# To do WTT specific things when calling MapIt.
+
+require_once "../commonlib/phplib/mapit.php";
+
+function mapit_postcode($pc, $opts = array(), $errors = array()) {
+    if (OPTION_MAPIT_GENERATION) {
+        $opts['generation'] = OPTION_MAPIT_GENERATION;
+    }
+    return mapit_call('postcode', $pc, $opts, $errors);
+}
+
+function mapit_areas($areas, $opts = array()) {
+    if (OPTION_MAPIT_GENERATION) {
+        $opts['generation'] = OPTION_MAPIT_GENERATION;
+    }
+    return mapit_call('areas', $areas, $opts);
+}

--- a/web/index.php
+++ b/web/index.php
@@ -8,8 +8,8 @@
  */
 
 require_once "../phplib/fyr.php";
+require_once "../phplib/mapit.php";
 require_once "../commonlib/phplib/utility.php";
-require_once "../commonlib/phplib/mapit.php";
 require_once '../commonlib/phplib/dadem.php';
 require_once "../commonlib/phplib/votingarea.php";
 
@@ -207,7 +207,7 @@ if ($pc) {
         exit;
     }
 
-    $voting_areas = mapit_call('postcode', $pc, array(), array(
+    $voting_areas = mapit_postcode($pc, array(), array(
         400 => MAPIT_BAD_POSTCODE,
         404 => MAPIT_POSTCODE_NOT_FOUND,
     ));

--- a/web/lords.php
+++ b/web/lords.php
@@ -11,7 +11,6 @@
  */
 require_once "../phplib/fyr.php";
 require_once "../commonlib/phplib/utility.php";
-require_once "../commonlib/phplib/mapit.php";
 require_once '../commonlib/phplib/dadem.php';
 require_once "../commonlib/phplib/votingarea.php";
 

--- a/web/who.php
+++ b/web/who.php
@@ -26,9 +26,9 @@ $attend_prep = array(
 );
 
 require_once "../phplib/fyr.php";
+require_once "../phplib/mapit.php";
 require_once "../commonlib/phplib/utility.php";
 require_once "../commonlib/phplib/dadem.php";
-require_once "../commonlib/phplib/mapit.php";
 require_once "../commonlib/phplib/votingarea.php";
 
 $fyr_postcode = get_postcode();
@@ -149,7 +149,7 @@ function get_area_types() {
 // Find all the districts/constituencies and so on (we call them "voting
 // areas") for the postcode provided
 function postcode_to_areas($postcode) {
-    $voting_areas = mapit_call('postcode', $postcode);
+    $voting_areas = mapit_postcode($postcode);
     if (rabx_is_error($voting_areas)) {
         header('Location: ' . url_new('/', true, 'pc', $postcode));
         exit;

--- a/web/write.php
+++ b/web/write.php
@@ -9,9 +9,9 @@
  */
 
 require_once "../phplib/fyr.php";
+require_once "../phplib/mapit.php";
 require_once "../phplib/forms.php";
 require_once "../phplib/queue.php";
-require_once "../commonlib/phplib/mapit.php";
 require_once "../commonlib/phplib/dadem.php";
 require_once "../commonlib/phplib/votingarea.php";
 require_once "../commonlib/phplib/utility.php";
@@ -663,7 +663,7 @@ if ($stash['group_msg']) {
     }
 
     //Get the electoral body information
-    $voting_areas = mapit_call('postcode', $fyr_values['pc']);
+    $voting_areas = mapit_postcode($fyr_values['pc']);
     mapit_check_error($voting_areas);
     $area_ids = array_keys($voting_areas['areas']);
 
@@ -749,7 +749,7 @@ if ($stash['group_msg']) {
     } else {
         // Check that the representative represents this postcode
         if (!$fyr_values['pc']) mismatch_error();
-        $postcode_areas = mapit_call('postcode', $fyr_values['pc']);
+        $postcode_areas = mapit_postcode($fyr_values['pc']);
         mapit_check_error($postcode_areas);
         $area_ids = array_keys($postcode_areas['areas']);
         if (!in_array($fyr_representative['voting_area'], $area_ids)) {


### PR DESCRIPTION
In April, new councils/wards will go live on MapIt but we don't want to use them until the elections to those councils in May. This commit lets WriteToThem continue to use an old MapIt generation.

Test suite passes.