### PR TITLE
Turned off current survey and generalised surveygizmo template

### DIFF
--- a/templates/website/surveygizmo-survey.html
+++ b/templates/website/surveygizmo-survey.html
@@ -1,9 +1,8 @@
 <?php
 
-$values['title'] = "Help us by answering a few quick questions";
-$values['robots'] = 'noindex, nofollow';
-$url = 'https://www.surveygizmo.com/s3/4563120/A-few-more-questions-2?__no_style=true&amp;__ref=pol-info-survey&amp;message_id=' . $values['id'];
 
+$values['robots'] = 'noindex, nofollow';
+$url = $values["survey_url"];
 template_draw('header', $values);
 
 ?>
@@ -22,4 +21,4 @@ template_draw('header', $values);
     </div>
 </div>
 
-<?php template_draw('footer', $values);
+<?php template_draw('footer', $values);?>

--- a/templates/website/surveygizmo-survey.html
+++ b/templates/website/surveygizmo-survey.html
@@ -21,4 +21,4 @@ template_draw('header', $values);
     </div>
 </div>
 
-<?php template_draw('footer', $values);?>
+<?php template_draw('footer', $values);

--- a/web/firsttime.php
+++ b/web/firsttime.php
@@ -41,8 +41,8 @@ $values['cobrand'] = $cobrand;
 // Current url for local councillor name recognition survey
 // https://www.surveygizmo.com/s3/5057760/WTT-Name-Recognition-Local-Council
 
-local_council_codes = ['DIW','CED','LBW','COP','LGE','MTW','UTE','UTW'];
-$wrote_to_councillor = in_array($values["recipient_type"], local_council_codes);
+$local_council_codes = ['DIW','CED','LBW','COP','LGE','MTW','UTE','UTW'];
+$wrote_to_councillor = in_array($values["recipient_type"], $local_council_codes);
 
 $send_to_survey_gizmo = $wrote_to_councillor; 
 // use rand(0, 1); for a 50% referral rate 

--- a/web/firsttime.php
+++ b/web/firsttime.php
@@ -38,18 +38,23 @@ $values['cobrand'] = $cobrand;
 
 
 // SurveyGizmo survey hook
-// Current url for Proxy Use Survey - but will not be displayed
+// Current url for local councillor name recognition survey
+// https://www.surveygizmo.com/s3/5057760/WTT-Name-Recognition-Local-Council
 
-$send_to_survey_gizmo = 0; 
+local_council_codes = ['DIW','CED','LBW','COP','LGE','MTW','UTE','UTW'];
+$wrote_to_councillor = in_array($values["recipient_type"], local_council_codes);
+
+$send_to_survey_gizmo = $wrote_to_councillor; 
 // use rand(0, 1); for a 50% referral rate 
 
 if ($send_to_survey_gizmo == 1) {
     $values['title'] = "Help us by answering a few quick questions";
-    $values['survey_url'] = 'https://www.surveygizmo.com/s3/" . 
-							"4563120/A-few-more-questions-2" .
-							"?__no_style=true&amp;" .
-							"__ref=pol-info-survey&amp;message_id=' .
-							$values['id'];
+    $values['survey_url'] = 'https://www.surveygizmo.com/s3/' .
+	'5057760/WTT-Name-Recognition-Local-Council' . 
+	'?__no_style=true&amp;' .
+	'__ref=WTT-Name-Recognition-Local-Councily&amp;' .
+	'recipient_id=' . $values['recipient_id'] . '&amp;' .
+	'first_use=' . ($values['questionnaire_1_yes'] ? 'true' : 'false');
     template_draw("surveygizmo-survey", $values);
 } else {
     // Questionnaire done

--- a/web/firsttime.php
+++ b/web/firsttime.php
@@ -47,7 +47,7 @@ $wrote_to_councillor = in_array($values["recipient_type"], $local_council_codes)
 $send_to_survey_gizmo = $wrote_to_councillor; 
 // use rand(0, 1); for a 50% referral rate 
 
-if ($send_to_survey_gizmo == 1) {
+if ($send_to_survey_gizmo) {
     $values['title'] = "Help us by answering a few quick questions";
     $values['survey_url'] = 'https://www.surveygizmo.com/s3/' .
 	'5057760/WTT-Name-Recognition-Local-Council' . 

--- a/web/firsttime.php
+++ b/web/firsttime.php
@@ -37,11 +37,20 @@ $values = msg_admin_get_message($result);
 $values['cobrand'] = $cobrand;
 
 
-// Proxy Information Survey
+// SurveyGizmo survey hook
+// Current url for Proxy Use Survey - but will not be displayed
 
-$rand = rand(0, 1); // high rate when want lots of data
-if ($rand == 0) {
-    template_draw("surveygizmo-proxy", $values);
+$send_to_survey_gizmo = 0; 
+// use rand(0, 1); for a 50% referral rate 
+
+if ($send_to_survey_gizmo == 1) {
+    $values['title'] = "Help us by answering a few quick questions";
+    $values['survey_url'] = 'https://www.surveygizmo.com/s3/" . 
+							"4563120/A-few-more-questions-2" .
+							"?__no_style=true&amp;" .
+							"__ref=pol-info-survey&amp;message_id=' .
+							$values['id'];
+    template_draw("surveygizmo-survey", $values);
 } else {
     // Questionnaire done
     template_draw("survey-done", $values);


### PR DESCRIPTION
The current wtt proxy use survey is turned off.

The survey title and url are moved up to firsttime.php so all config is in the same file.

Old survey details left in place because the parameters are useful for next time