### PR TITLE
Don't set Proxy headers on traffic to /admin/services

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -54,8 +54,12 @@ RewriteEngine on
 # Example simple rewrite rule
 #RewriteRule /test /index.php [PT]
 
-SSLProxyEngine on
-ProxyPass /admin/services/ https://services.mysociety.org/admin/
+<Location "/admin/services/">
+  SSLProxyEngine  on
+  ProxyPass       https://services.mysociety.org/admin/
+  ProxyAddHeaders off
+  RequestHeaders  unset X-Forwarded-For
+</Location>
 
 RewriteRule ^/lord/?$ /lords [R]
 RewriteRule ^/lords/$ /lords [R]


### PR DESCRIPTION
As we will be trusting internal IPs in mod_remoteip, we'll need to ensure that we strip out the original IP in these requests - otherwise they get blocked by the internal-requests-only policy for services.

This area requires authentication in the back-end so we'll have a record of the user, and the original IP will be recorded in the WTT logs, just as it is now.

Once this is finalised, we can deploy at the same time as removing the Location block for /admin/services with the HTTP AUTH stanza in the central single-vhost.conf.ugly template - this is no longer needed as the back-end Auth was sorted some time back.