### PR TITLE
Remove link to stats from questionnaire emails

### DIFF
--- a/templates/emails/questionnaire
+++ b/templates/emails/questionnaire
@@ -22,12 +22,10 @@ NO, but I didn't expect/require a response! - please click here:
 NO, they did not reply! - please click here:
 <?=$values['no_url']?>
 
-Your feedback allows us to publish performance tables of the responsiveness
+Your feedback allows us to analyse the responsiveness
 of all the politicians in the UK. We are keen to give politicians the credit
 they deserve when they respond promptly to their constituents. We think it's
 also worth highlighting the representatives who don't.
-
-Check how your MP's doing here: https://www.writetothem.com/stats
 
 Please do not reply to this mail. If you have a question or comment about the
 site, please send an email to <?=$values['contact_email']?>

--- a/templates/emails/questionnaire.html
+++ b/templates/emails/questionnaire.html
@@ -42,9 +42,7 @@
 
   <br>
 
-  <p style="<?= $values['p_style'] ?>">Your feedback allows us to publish performance tables of the responsiveness of all the politicians in the UK. We are keen to give politicians the credit they deserve when they respond promptly to their constituents. We think it's also worth highlighting the representatives who don't.</p>
-
-  <p style="<?= $values['p_style'] ?>">Check how your MP's doing here: <a href="https://www.writetothem.com/stats">www.writetothem.com/stats</a></p>
+  <p style="<?= $values['p_style'] ?>">Your feedback allows us to analyse the responsiveness of all the politicians in the UK. We are keen to give politicians the credit they deserve when they respond promptly to their constituents. We think it's also worth highlighting the representatives who don't.</p>
 
   <p style="<?= $values['p_style'] ?>">A copy of your letter is below. <b>Note that we do not keep a copy of your letter on file, so please keep this email for your records.</b></p>
 


### PR DESCRIPTION
If we stop drawing people's attention to the out of date responsiveness statistics, this should reduce the number of questions and complaints about why the stats are out of date.