### PR TITLE
Extend "a few minutes" wait time

### DIFF
--- a/templates/website/write-checkemail.html
+++ b/templates/website/write-checkemail.html
@@ -19,7 +19,7 @@ template_draw('header', $values);
     <div class="large-8 large-centered columns">
 
         <h2>Now check your email!</h2>
-        <p>The confirmation email may take a few minutes to arrive &mdash; please be patient.</p>
+        <p>The confirmation email can take up to 10-15 minutes to arrive &mdash; please be patient.</p>
 
     </div>
 </div>


### PR DESCRIPTION
It's common for people to email WriteToThem support saying their confirmation email hasn't arrived, and when you check in the database, the message is already confirmed and sent - i.e. they confirmed themselves, having just not waited long enough for the email to come through. If we tell them a longer potential wait time (and use more precise words than "a few"), that should cut down on this type of support.