### PR TITLE
Add advice on writing on behalf of someone else

### DIFF
--- a/templates/website/about-constituency.html
+++ b/templates/website/about-constituency.html
@@ -25,6 +25,7 @@ template_draw('header', $values);
 <a name="top"></a>
 <ul class="side-nav">
 <li><a href="#lookup">I know my address but not my postcode</a></li>
+<li><a href="#onbehalf">I’m writing on behalf of someone else</a></li>
 <li><a href="#services">I’m a member of the armed forces</a></li>
 <li><a href="#expat">I’m an expatriate</a></li>
 <li><a href="#bot">I live in a British Overseas Territory</a></li>
@@ -43,6 +44,25 @@ href="https://www.royalmail.com/find-a-postcode">Postcode Finder</a> - put in
 any UK address and it will tell you the postcode.</p>
 </dd>
 
+<dt><a name="onbehalf"></a>I’m writing on behalf of someone else</dt>
+
+<dd>
+    <p>It’s better if that person can write their own message. By convention,
+        representatives will only act on behalf of their own constituents, and
+        before taking up any case, they will always want to make sure they have
+        the permission of the person(s) it concerns.</p>
+    
+    <p>If you’re writing on behalf of someone who doesn’t have capacity, the
+        ‘correct’ procedure is to contact your own representative and ask
+        them to take up the matter with the most appropriate colleague. So,
+        use your own address and postcode, and in your message, give the details
+        of the person you’re writing about.</p>
+
+    <p>This is also the case if you’re writing about, say, your office
+        premises, or another business. Use your home address and postcode.</p>
+
+</dd>
+    
 <dt><a name="services"></a>I’m a member of the armed forces</dt>
 
 <dd><p><strong>How do I register to vote?</strong> As a member of the armed


### PR DESCRIPTION
(TL;DR don't.) This is the most common cause of messages getting trapped by the 'address has a postcode in it' filter: "I'm writing on behalf of my mum who is one of your constituents", they've used mum's postcode to get the correct rep, and then filled in their own details including postcode in an address field where it shouldn't go.

There is of course no guarantee that people will read the FAQs, but maybe this will help a little bit.