### PR TITLE
Add template for multiple postcodes misuse

### DIFF
--- a/templates/website/problem-postcode.html
+++ b/templates/website/problem-postcode.html
@@ -1,0 +1,48 @@
+<?php
+
+if (!isset($values['skip_header'])) {
+    $values['title'] = "Problem with your message";
+    $values['robots'] = 'noindex, nofollow';
+    template_draw('header', $values);
+}
+
+?>
+
+<div class="row write-header">
+    <div class="large-8 large-centered columns">
+
+        <h2>It looks like you’ve included more than one postcode</h2>
+
+    </div>
+</div>
+
+<div class="row">
+    <div class="large-8 large-centered columns" role="alert">
+
+        <p>Sorry, but please read <a href="/about-qa#onlyrep">this</a> to understand
+            why our site only lets you write to <em>your own elected representatives</em>,
+            not those for other parts of the country.</p>
+
+        <p>If we didn’t do this, then representatives would be snowed under with mail
+            from all and sundry, and that would mean they ignored the important mail from
+            their own constituents. They might even bin <strong>all</strong> messages
+            sent via WriteToThem.com.</p>
+
+        <p>Either of which would be A Bad Thing.</p>
+
+        <p>If you’re writing <a href="/about-qa#onbehalf">on behalf of someone else</a>,
+            the ‘correct’ procedure is to write to your own representative and ask
+            them to take up the matter with the most appropriate colleague.</p>
+
+        <p>Please <a href="/">start again from the beginning</a>, use your own
+            address and postcode, and in your message, give the details of the
+            person or place you’re writing about.</p>
+
+    </div>
+</div>
+
+<?php
+
+if (!isset($values['skip_header'])) {
+    template_draw('footer', $values);
+}


### PR DESCRIPTION
Adds a template for the message rule 'address has a postcode in it' to use. At the moment, when the rule fires, the message is frozen for an administrator to look at. With this template in place, we would be able to try showing it to people instead, and telling them they can't use more than one postcode in their message. (It would be better to detect and warn as soon as a user enters something in the address field that looks like a postcode, but that needs ticketing separately.)

The template should not be put into use until the guidance in #455 is live!