### PR TITLE
Link to No. 10's contact form for the PM

### DIFF
--- a/templates/website/write-write.html
+++ b/templates/website/write-write.html
@@ -40,15 +40,7 @@ template_draw('header', $values);
         <p><a href="/about-qa#onlyrep">Click here to understand why doing otherwise is A Bad Thing</a>.</p>
 
         <p>If you are <em>not</em> a constituent and wish to contact Boris Johnson, you
-        may write to him at the address below:</p>
-
-        <ul class="vcard">
-          <li class="fn">The Rt Hon Boris Johnson</li>
-          <li class="title">Prime Minister</li>
-          <li class="street-address">10 Downing Street</li>
-          <li class="locality">London</li>
-          <li class="zip">SW1A 2AA</li>
-        </ul>
+            may do so via the Number 10 Downing Street website: <a href="https://contact.no10.gov.uk/">https://contact.no10.gov.uk/</a></p>
 
         <p>If you are a constituent of Uxbridge and South Ruislip, read on...</p>
 


### PR DESCRIPTION
Removes the postal address for the Prime Minister and replaces it with a link to the No. 10 website.

Fixes #430, also fixes #377 by making a decision.