### PR TITLE
Improved devcontainer environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+    "name":"theyworkforyou",
+    "dockerComposeFile":"../docker-compose.yml",
+    "service":"fyr",
+    "workspaceFolder":"/workspaces/writetothem",
+    "initializeCommand":[
+       ".devcontainer/initializeCommand"
+    ],
+    "onCreateCommand": [
+      ".devcontainer/onCreateCommand"
+    ],
+    "portsAttributes":{
+       "8085":{
+          "label":"WTT"
+       }
+    },
+    "forwardPorts":[
+      8085
+    ],
+    "customizations":{
+       "vscode":{
+          "extensions":[
+             "ms-vscode.test-adapter-converter",
+             "ms-azuretools.vscode-docker",
+             "bmewburn.vscode-intelephense-client",
+             "felixfbecker.php-debug",
+             "recca0120.vscode-phpunit"
+          ]
+       }
+    }
+ }

--- a/.devcontainer/initializeCommand
+++ b/.devcontainer/initializeCommand
@@ -1,0 +1,2 @@
+#!/bin/sh
+[ ! -d "foundation/docs" ] && git submodule update --init || echo "Submodules already loaded, skipping."

--- a/.devcontainer/onCreateCommand
+++ b/.devcontainer/onCreateCommand
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This script is run inside the container after it is created.
+apt update
+apt install -y ruby-full build-essential zlib1g-dev
+gem install bundler -v '1.17.2'
+bundle install

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,25 @@
+name: Push mirror to git.mysociety.org
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+
+    - name: Push branch to git.mysociety.org
+      id: push_to_mirror
+      uses: mysociety/action-git-pusher@v1.1.1
+      with:
+        git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
+        ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}
+        tag: ${{ github.ref_name }} 
+        remote: 'ssh://gh-public@git.mysociety.org/data/git/public/writetothem.git'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysocietyorg/apache-php-fpm:stretch
+FROM mysocietyorg/apache-php-fpm:bullseye
 LABEL maintainer="sysadmin@mysociety.org"
 
 COPY ./conf/packages /tmp/packages

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ directory for updates, and recompile the CSS files as necessary:
     cd web/static
     bundle exec compass watch
 
+If using the codespaces/devcontainer setup, the above will be setup on container creation, and `script/watch` will watch for changes.
+
 ## Acknowledgements
 
 Thanks to [Browserstack](https://www.browserstack.com/) who let us use their

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ To stop the environment in this case run:
 The first time you run the environment, a local image will be built for the app
 container and the database will have the schema loaded automatically.
 
-Once the environment is running, it should be accessible at http://127.0.0.1.xip.io:8085/
-(note that you'll get an error if you simply visit localhost:8085 at present).
+Once the environment is running, it should be accessible at http://localhost:8085.
 
 If you need to rebuild the app container, you can do so by running:
 

--- a/phplib/emailform.php
+++ b/phplib/emailform.php
@@ -10,14 +10,7 @@
 *
 */
 require_once "../phplib/fyr.php";
-
-# try and import the PHPMailer library using the original method, but switch if fails (for testing help pages)
-
-if (file_exists("libphp-phpmailer/src/PHPMailer.php")) {
-    require_once "libphp-phpmailer/src/PHPMailer.php";
-} else {
-    require_once "libphp-phpmailer/class.phpmailer.php";
-}
+require_once "libphp-phpmailer/src/PHPMailer.php";
 
 /* setup the fields that are wanted on the contact form,
 *    this will be dynamically built using emailform_display,
@@ -271,4 +264,3 @@ function emailform_send_message () {
     }
     return $success;
 }
-

--- a/phplib/emailform.php
+++ b/phplib/emailform.php
@@ -10,7 +10,14 @@
 *
 */
 require_once "../phplib/fyr.php";
-require_once "libphp-phpmailer/src/PHPMailer.php";
+
+# try and import the PHPMailer library using the original method, but switch if fails (for testing help pages)
+
+if (file_exists("libphp-phpmailer/src/PHPMailer.php")) {
+    require_once "libphp-phpmailer/src/PHPMailer.php";
+} else {
+    require_once "libphp-phpmailer/class.phpmailer.php";
+}
 
 /* setup the fields that are wanted on the contact form,
 *    this will be dynamically built using emailform_display,

--- a/phplib/emailform.php
+++ b/phplib/emailform.php
@@ -264,3 +264,4 @@ function emailform_send_message () {
     }
     return $success;
 }
+

--- a/phplib/fyr.php
+++ b/phplib/fyr.php
@@ -40,7 +40,13 @@ template_set_style($dir . "/../templates/website");
 global $cobrand;
 $cobrand = null;
 if (array_key_exists('HTTP_HOST', $_SERVER)) {
-    $host_parts = explode('.', $_SERVER['HTTP_HOST'], 2);
+    # if localhost or localhost:8085, skip the dot exploding step
+    $localhost_values = array('localhost', 'localhost:8085');
+    if (in_array( $_SERVER['HTTP_HOST'], $localhost_values)) {
+        $host_parts = array('localhost', 'localhost');
+    } else {
+        $host_parts = explode('.', $_SERVER['HTTP_HOST'], 2);
+    }
     if ($host_parts[1] == OPTION_WEB_DOMAIN && $host_parts[0] != 'www') {
         $cobrand = $host_parts[0];
     }

--- a/script/watch
+++ b/script/watch
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Watch SASS files for changes and recompile
+
+cd web/static
+bundle exec compass watch


### PR DESCRIPTION
This PR adds the basic boilerplate for a devcontainer setup to work in VSCode or Codespaces.

This is to make it easier to test changes to help text, donation messaging, surveys, etc.

This includes:

- Github Action to mirror back to git.mysociety.org
- Loading Ruby/Compass as part of container creation (doesn't change existing docker instructions)
- Modification to code to fix the issue referenced in the readme that 'localhost' can't be used as a URL in development environment. 
- Extra catch around import of PHPMailer to remove an error that prevents reviewing the content of help pages, etc.

In principle, this shouldn't have any impact on other dev environments or how it works in production - but those last two points need a check. 