### PR TITLE
Fix headers and envelope sender in Quality Deity email

### DIFF
--- a/bin/admin_reminder_mail
+++ b/bin/admin_reminder_mail
@@ -250,7 +250,7 @@ $headers = array(
 
     if ($realrun) {
         verbose("sending email to $dest");
-        mail($dest, $subject, $mail, $headers);
+        mail($dest, $subject, $mail, $headers, "-f $from");
     } else {
         verbose("printing email");
         print "To: $dest\n\n"; 


### PR DESCRIPTION
The headers have been broken for ages, so this fixes that (so `X-Mailer` isn't included in the `From` header but actually added as a header).

This also adds a fifth option that will pass `-f $from` to sendmail to ensure a sensible envelope-sender is set that should match the `From` header and help pass SPF and DMARC.