### PR TITLE
Add exoscale subcontroller to privacy policy

### DIFF
--- a/templates/website/about-privacy.html
+++ b/templates/website/about-privacy.html
@@ -104,6 +104,22 @@ template_draw('header', $values);
                         policy may be seen on request.
                     </li>
                     <li>
+                        We use a subprocessor called <a href="https://www.exoscale.com/">Exoscale</a> 
+                        to help analyse of survey data. This involves the use of LLMs to
+                        anonymise free-text survey responses. This uses an LLM (a type of AI) 
+                        to anonymise free-text responses and label groups of responses. 
+                        It does not include the content of messages sent through WriteToThem. 
+                        Exoscale is a GPU infrastructure orchestrator that
+                        enables access to open weight LLMs on controlled infrastructure, without
+                        logging or use of information for training. We are satisfied that
+                        Exoscale&rsquo;s
+                        <a href="https://www.exoscale.com/security/">security approach</a>
+                        and
+                        <a href="https://www.exoscale.com/dpa/">data processing agreement</a>
+                        meet our standards for secure and GDPR compliant processing of personal
+                        information.
+                    </li>
+                    <li>
                         We will never sell or otherwise distribute any information you give
                         WriteToThem to organisations or individuals outside of mySociety, except
                         if required to do so by UK law.


### PR DESCRIPTION
Add exoscale as a subprocessor to the privacy policy (used for wtt insights).